### PR TITLE
Reader is mobile-only: remove reader web Hosting site + target

### DIFF
--- a/.firebaserc
+++ b/.firebaserc
@@ -5,7 +5,6 @@
   "targets": {
     "wolly-1133d": {
       "hosting": {
-        "reader": ["wolly-reader"],
         "creator-hub": ["wolly-creator-hub"],
         "backoffice": ["wolly-backoffice"]
       }

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,6 +4,9 @@ name: Deploy
 #   push to develop  -> MOCK environment  (web: Hosting preview channel "mock", Android: "qa" testers)
 #   push to main     -> PROD environment  (web: Hosting live,                 Android: "production" testers)
 #
+# The reader is a mobile app only — it is distributed as an Android APK via App
+# Distribution and has no web Hosting site. The web surfaces are creator-hub and backoffice.
+#
 # Required GitHub secret:
 #   FIREBASE_SERVICE_ACCOUNT  – the full Firebase Admin SDK service-account JSON.
 #     The service account needs these IAM roles on project wolly-1133d:
@@ -13,7 +16,7 @@ name: Deploy
 #
 # Prerequisites in Firebase (one-time):
 #   • Hosting sites matching the targets in .firebaserc
-#     (wolly-reader, wolly-creator-hub, wolly-backoffice) created and applied.
+#     (wolly-creator-hub, wolly-backoffice) created and applied.
 #   • App Distribution tester groups named "qa" and "production".
 
 on:
@@ -111,10 +114,6 @@ jobs:
         working-directory: apps/reader
         run: flutter pub get
 
-      - name: Build reader web
-        working-directory: apps/reader
-        run: flutter build web --release
-
       - name: Build Android APK
         working-directory: apps/reader
         run: flutter build apk --release
@@ -123,19 +122,6 @@ jobs:
         env:
           FIREBASE_SERVICE_ACCOUNT: ${{ secrets.FIREBASE_SERVICE_ACCOUNT }}
         run: printf '%s' "$FIREBASE_SERVICE_ACCOUNT" > "$RUNNER_TEMP/sa.json"
-
-      - name: Deploy reader web
-        env:
-          GOOGLE_APPLICATION_CREDENTIALS: ${{ runner.temp }}/sa.json
-        run: |
-          if [ "${{ needs.config.outputs.hosting_channel }}" = "live" ]; then
-            firebase deploy --only hosting:reader \
-              --project "$FIREBASE_PROJECT" --non-interactive
-          else
-            firebase hosting:channel:deploy "${{ needs.config.outputs.hosting_channel }}" \
-              --only reader \
-              --project "$FIREBASE_PROJECT" --expires 30d --non-interactive
-          fi
 
       - name: Distribute Android APK to testers
         env:

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ surfaces plus the shared contracts that keep them in sync.
 ```
 wolly/
 ├── apps/
-│   ├── reader/         # Flutter mobile/web app — readers browse & read books (BLoC)
+│   ├── reader/         # Flutter mobile app — readers browse & read books (BLoC)
 │   ├── creator-hub/    # Next.js web app — authors create, publish & track books
 │   └── backoffice/     # Next.js web app — staff moderation / publishing workflow (Phase 5)
 ├── packages/
@@ -53,7 +53,9 @@ shape the reader expects, so they appear in the reader immediately.
 
 ## Deployment
 
-Hosting uses Firebase multi-site targets (`reader`, `creator-hub`, `backoffice`).
-The site IDs in `.firebaserc` (`wolly-reader`, `wolly-creator-hub`, `wolly-backoffice`)
-are placeholders — create the matching Hosting sites in the Firebase console (or
-adjust the IDs) before the first `firebase deploy`.
+CI (`.github/workflows/deploy.yml`) deploys on push: `develop` → mock, `main` → prod.
+
+- **Web** (`creator-hub`, `backoffice`) deploy to Firebase Hosting multi-site
+  targets (`wolly-creator-hub`, `wolly-backoffice` in `.firebaserc`).
+- **Reader** is a **mobile app only** — it ships as an Android APK via Firebase
+  App Distribution (`qa` / `production` tester groups). It has no web Hosting site.

--- a/firebase.json
+++ b/firebase.json
@@ -8,14 +8,6 @@
   },
   "hosting": [
     {
-      "target": "reader",
-      "public": "apps/reader/build/web",
-      "ignore": ["firebase.json", "**/.*", "**/node_modules/**"],
-      "rewrites": [{ "source": "**", "destination": "/index.html" }],
-      "cleanUrls": true,
-      "trailingSlash": false
-    },
-    {
       "target": "creator-hub",
       "public": "apps/creator-hub/out",
       "ignore": ["firebase.json", "**/.*", "**/node_modules/**"],


### PR DESCRIPTION
Syncs the reader-hosting removal to prod.

- Deletes the `wolly-reader` Firebase Hosting site and its target from `firebase.json` / `.firebaserc` (the site has already been deleted in Firebase).
- `deploy.yml` reader job drops the web build + Hosting deploy; keeps the Android APK build + App Distribution.
- Docs updated: the reader is a **mobile app only** (no web Hosting site).

Verified green on `develop` (mock deploy: web surfaces to Hosting, reader APK to `qa`).