### PR TITLE
Harden CI: clear lint/analyzer debt, make gates blocking

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,11 +19,8 @@ jobs:
       - run: npm ci
       - name: Typecheck shared schema
         run: npx tsc --noEmit -p packages/schema/tsconfig.json
-      # Advisory until the apps' pre-existing lint debt is cleared; then drop
-      # continue-on-error to make it blocking.
       - name: Lint
         run: npm run lint
-        continue-on-error: true
       - name: Build web apps
         run: npm run build
 
@@ -38,9 +35,6 @@ jobs:
       - name: Install dependencies
         working-directory: apps/reader
         run: flutter pub get
-      # Advisory until the reader's pre-existing analyzer debt is cleared; then
-      # drop continue-on-error to make it blocking.
       - name: Analyze
         working-directory: apps/reader
         run: flutter analyze --no-fatal-infos
-        continue-on-error: true

--- a/apps/creator-hub/eslint.config.mjs
+++ b/apps/creator-hub/eslint.config.mjs
@@ -20,6 +20,13 @@ const eslintConfig = [
       "next-env.d.ts",
     ],
   },
+  {
+    // Standalone Node (CommonJS) ops/migration scripts legitimately use require().
+    files: ["scripts/**/*.js"],
+    rules: {
+      "@typescript-eslint/no-require-imports": "off",
+    },
+  },
 ];
 
 export default eslintConfig;

--- a/apps/reader/lib/core/widgets/auth_gate.dart
+++ b/apps/reader/lib/core/widgets/auth_gate.dart
@@ -88,7 +88,7 @@ class _OnboardingCheckState extends State<_OnboardingCheck> {
       final data = doc.data();
       final prefs = data?['genre_prefs'];
       final completed = data?['onboardingCompleted'] == true;
-      final hasPrefs = prefs is List && (prefs as List).isNotEmpty;
+      final hasPrefs = prefs is List && prefs.isNotEmpty;
       setState(() {
         _needsOnboarding = !completed && !hasPrefs;
         _checking = false;

--- a/apps/reader/lib/features/store/data/paystack_service.dart
+++ b/apps/reader/lib/features/store/data/paystack_service.dart
@@ -37,6 +37,6 @@ class PaystackService {
 
   static String generateReference(String bookId) {
     final ts = DateTime.now().millisecondsSinceEpoch;
-    return 'WOLLY_${bookId}_\$ts';
+    return 'WOLLY_${bookId}_$ts';
   }
 }


### PR DESCRIPTION
Clears the lint/analyzer debt and makes the CI gates blocking again.

- **creator-hub eslint**: the 33 errors were all `@typescript-eslint/no-require-imports` in `scripts/*.js` (standalone Node CommonJS ops scripts). Added a scoped eslint override allowing `require()` there → 0 errors.
- **backoffice eslint**: already clean.
- **reader analyzer**: the only warning-level (fatal) issue was a bug in `paystack_service.dart` — an escaped `\$ts` left `ts` unused and produced a literal `$ts` in the payment reference. Fixed the interpolation. The remaining ~97 analyzer items are `info` (non-fatal under `--no-fatal-infos`).
- **ci.yml**: dropped `continue-on-error` from the Lint (web) and Analyze (reader) steps so they block again.

The blocking gates run on this PR — green here means the debt is cleared.